### PR TITLE
Fix missing `clang-format-13` command by adding all llvm repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update &&\
 
 RUN wget -nv -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - &&\
     apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs` main" &&\
+    apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-12 main" &&\
+    apt-add-repository -y "deb http://apt.llvm.org/`lsb_release -cs`/ llvm-toolchain-`lsb_release -cs`-13 main" &&\
     apt-get install -y --no-install-recommends \
         clang-format-6.0 \
         clang-format-7 \


### PR DESCRIPTION
For some reason the package disappeared from the only repo that was used before (just v13).